### PR TITLE
Handle errors

### DIFF
--- a/run-dev.sh
+++ b/run-dev.sh
@@ -3,3 +3,5 @@
 docker run --name ubuntu -t -d ubuntu bash
 
 CONTAINER=ubuntu CONTAINER_SHELL=bash KEYPATH=id_rsa PORT=2222 HTTP_PORT=8022 AUTH_MECHANISM=noAuth nodemon -e coffee server.coffee | bunyan
+
+docker stop ubuntu && docker rm --force ubuntu

--- a/src/session-handler-factory.coffee
+++ b/src/session-handler-factory.coffee
@@ -38,6 +38,7 @@ module.exports = (container, shell) ->
         channel = accept()
         _container = docker.getContainer container
         _container.exec {Cmd: [shell, '-c', info.command], AttachStdin: true, AttachStdout: true, AttachStderr: true, Tty: false}, (err, exec) ->
+          return log.error {container: container}, 'Exec error', err if err
           exec.start {stdin: true, Tty: true}, (err, _stream) ->
             stream = _stream
             stream.on 'data', (data) ->
@@ -66,6 +67,7 @@ module.exports = (container, shell) ->
 
         _container = docker.getContainer container
         _container.exec {Cmd: [shell], AttachStdin: true, AttachStdout: true, Tty: true}, (err, exec) ->
+          return log.error {container: container}, 'Exec error', err if err
           exec.start {stdin: true, Tty: true}, (err, _stream) ->
             stream = _stream
             forwardData = false

--- a/src/session-handler-factory.coffee
+++ b/src/session-handler-factory.coffee
@@ -38,7 +38,9 @@ module.exports = (container, shell) ->
         channel = accept()
         _container = docker.getContainer container
         _container.exec {Cmd: [shell, '-c', info.command], AttachStdin: true, AttachStdout: true, AttachStderr: true, Tty: false}, (err, exec) ->
-          return log.error {container: container}, 'Exec error', err if err
+          if err
+            log.error {container: container}, 'Exec error', err
+            return closeChannel()
           exec.start {stdin: true, Tty: true}, (err, _stream) ->
             stream = _stream
             stream.on 'data', (data) ->
@@ -67,7 +69,9 @@ module.exports = (container, shell) ->
 
         _container = docker.getContainer container
         _container.exec {Cmd: [shell], AttachStdin: true, AttachStdout: true, Tty: true}, (err, exec) ->
-          return log.error {container: container}, 'Exec error', err if err
+          if err
+            log.error {container: container}, 'Exec error', err
+            return closeChannel()
           exec.start {stdin: true, Tty: true}, (err, _stream) ->
             stream = _stream
             forwardData = false


### PR DESCRIPTION
- Check whether `exec` calls are successful or error out
- Log error and bail if `exec` fails
- Clean up after running `docker-ssh` locally using `run-dev.sh`
