### PR TITLE
public key auth via authorized_keys file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ message if you whish to contribute to this project.
 - [ ] Customize the MOTD
 - [x] Simple user authentication; one user/password
 - [x] Authenticate users by username and password
-- [ ] Authenticate users by username and public key
+- [x] Authenticate users by username and public key
 - [ ] Secure copy implementation (SCP)
 - [ ] Secure FTP implementation (SFTP)
 
@@ -114,7 +114,7 @@ AUTH_MECHANISM    | Implemented | Description
 noAuth            | yes         | No authentication is performed, enter any user/password combination to logon
 simpleAuth        | yes         | Authenticate a predefined user/password, supports one user
 multiUser         | yes         | Authenticate a user according to a predefined lists of users and passwords
-privateKey        | **no**      | Private key authentication
+publicKey         | yes         | Public key authentication
 
 ## noAuth
 No authentication is performed. Any user/password combination is accepted by the server.
@@ -151,8 +151,24 @@ It is a single string with semicolon (;) separated user:password pairs.
     $ ssh -p 2222 luke@localhost
     $ luke@localhost's password: ****
 
-## privateKey
-No yet implemented.
+## publicKey
+Supports the authentication of a user against an authorized_keys file containing a list of public keys.
+Set `AUTH_MECHANISM=publicKey` to enable this authentication mechanism.
+The name of the authorized_keys file is configured by setting `AUTHORIZED_KEYS`.
+
+    $ cat ~/.ssh/id_rsa.pub > authorized_keys
+    $ docker run -d -p 2222:22 \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -v ./authorized_keys:/authorized_keys
+      -e CONTAINER=my-container -e AUTH_MECHANISM=publicKey \
+      -e AUTHORIZED_KEYS="/authorized_keys" \
+      jeroenpeeters/docker-ssh
+
+    $ ssh -p 2222 luke@localhost
+    
+     ###############################################################
+     ## Docker SSH ~ Because every container should be accessible ##
+     ###############################################################
 
 # Server Identity and Security
 The SSH server needs an RSA/EC private key in order to secure the connection and identify itself to clients.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "forever": "^0.15.1",
     "ssh2": "~0.4.11",
     "ssh2-connect": "0.0.7",
+    "buffer-equal-constant-time": "1.0.1",
     "uuid": "~2.0.1"
   }
 }

--- a/src/auth/index.coffee
+++ b/src/auth/index.coffee
@@ -3,4 +3,5 @@ module.exports = (authType) ->
     when 'noAuth' then require './noAuthHandler'
     when 'simpleAuth' then require './simpleAuth'
     when 'multiUser' then require './multiUserAuth'
+    when 'publicKey' then require './publicKeyAuth'
     else null

--- a/src/auth/publicKeyAuth.coffee
+++ b/src/auth/publicKeyAuth.coffee
@@ -1,0 +1,46 @@
+bunyan   = require 'bunyan'
+log      = bunyan.createLogger name: 'publicKeyAuth'
+env      = require '../env'
+fs       = require 'fs'
+crypto   = require 'crypto'
+ssh2     = require 'ssh2'
+ssh2_streams = require 'ssh2-streams';
+buffersEqual = require 'buffer-equal-constant-time'
+
+authorizedKeysFile = env.assert 'AUTHORIZED_KEYS'
+
+module.exports = (ctx) ->
+  if ctx.method is 'publickey'
+    # try to find a match in the authorized keys
+    log.info {user: ctx.username}, 'Checking public key against authorized keys'
+    authorizedKey = null
+    authorizedKeyIndex = 0 ;
+    fs.readFileSync(authorizedKeysFile).toString().split('\n').forEach (line) ->
+      authorizedKeyIndex++
+      if line.length > 0
+        pubKey = ssh2_streams.utils.genPublicKey(ssh2_streams.utils.parseKey(line))
+        if ctx.key.algo is pubKey.fulltype and buffersEqual(ctx.key.data, pubKey.public)
+          log.info 'Found authorized key matching client key at ' + authorizedKeysFile + ':' + authorizedKeyIndex
+          authorizedKey = pubKey
+
+    # no match: reject
+    if authorizedKey == null
+      log.info 'No authorized key matching the client key'
+      return ctx.reject();
+
+    if ctx.signature
+      verifier = crypto.createVerify(ctx.sigAlgo);
+      verifier.update(ctx.blob);
+      if verifier.verify(authorizedKey.publicOrig, ctx.signature)
+        log.info {user: ctx.username}, 'Public key auth succeeded'
+        return ctx.accept()
+      else
+        log.warn {user: ctx.username}, 'Authentication failed'
+        ctx.reject()
+    else
+      # if no signature present, that means the client is just checking
+      # the validity of the given public key
+      log.info {user: ctx.username}, 'No signature, the client is just checking validity of given public key'
+      return ctx.accept();
+
+  ctx.reject();


### PR DESCRIPTION
Hello.

This is a proposed implementation of public/private key authentication mechanism.

I've adapted [public key example](https://github.com/mscdex/ssh2#server-examples) from underlying ssh2 lib to use an authorized_keys file.

Thanks for reviewing.

Benoit
