### PR TITLE
Add argument 'SHELL_USER' to specify user which runs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ message if you whish to contribute to this project.
 - [ ] Secure copy implementation (SCP)
 - [ ] Secure FTP implementation (SFTP)
 - [ ] Access multiple containers
+- [x] Run commands as specific user
 
 # Add SSH capabilities to any container!
 Let's assume you have a running container with name 'web-server1'. Run the following command to start Docker-SSH:
@@ -187,6 +188,7 @@ KEYPATH        | ./id_rsa | path to a private key to use as server identity
 PORT           | 22       | ssh server listens on this port
 HTTP_ENABLED   | true     | enable/disable the web terminal
 HTTP_PORT      | 8022     | web terminal listens on this port
+SHELL_USER     | root     | Run commands as this user *(Note: independant from authentication user)*
 
 # Credits
 I couldn't have created Docker-SSH without the following great Node packages! Many thanks go to the authors of:

--- a/server.coffee
+++ b/server.coffee
@@ -13,6 +13,7 @@ ip              = process.env.IP or '0.0.0.0'
 keypath         = process.env.KEYPATH
 container       = process.env.CONTAINER
 shell           = process.env.CONTAINER_SHELL
+shell_user      = process.env.SHELL_USER || 'root'
 authMechanism   = process.env.AUTH_MECHANISM
 authenticationHandler = require('./src/auth') authMechanism
 
@@ -31,7 +32,7 @@ exitOnConfigError "Unknown AUTH_MECHANISM: #{authMechanism}"  unless authenticat
 options =
   privateKey: fs.readFileSync keypath
 
-sessionFactory = handlerFactory container, shell
+sessionFactory = handlerFactory container, shell, shell_user
 
 sshServer = new ssh2.Server options, (client, info) ->
   session = sessionFactory.instance()

--- a/src/session-handler-factory.coffee
+++ b/src/session-handler-factory.coffee
@@ -14,7 +14,7 @@ header = (container) ->
   " ###############################################################\r\n" +
   "\r\n"
 
-module.exports = (container, shell) ->
+module.exports = (container, shell, shell_user) ->
   instance: ->
     session = null
     channel = null
@@ -37,7 +37,7 @@ module.exports = (container, shell) ->
         log.info {container: container, command: info.command}, 'Exec'
         channel = accept()
         _container = docker.getContainer container
-        _container.exec {Cmd: [shell, '-c', info.command], AttachStdin: true, AttachStdout: true, AttachStderr: true, Tty: false}, (err, exec) ->
+        _container.exec {User: shell_user, Cmd: [shell, '-c', info.command], AttachStdin: true, AttachStdout: true, AttachStderr: true, Tty: false}, (err, exec) ->
           if err
             log.error {container: container}, 'Exec error', err
             return closeChannel()
@@ -68,7 +68,7 @@ module.exports = (container, shell) ->
         channel.write "#{header container}"
 
         _container = docker.getContainer container
-        _container.exec {Cmd: [shell], AttachStdin: true, AttachStdout: true, Tty: true}, (err, exec) ->
+        _container.exec {User: shell_user, Cmd: [shell], AttachStdin: true, AttachStdout: true, Tty: true}, (err, exec) ->
           if err
             log.error {container: container}, 'Exec error', err
             return closeChannel()


### PR DESCRIPTION
If SHELL_USER is not provided, 'root' will be used.

This also resolves #25